### PR TITLE
Feature/support nav2018 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+/.vs/EtwPerformanceProfiler/v15/Server/sqlite3

--- a/EtwPerformanceProfiler/App Objects/PAG50000.txt
+++ b/EtwPerformanceProfiler/App Objects/PAG50000.txt
@@ -285,7 +285,7 @@ OBJECT Page 50000 Performance Profiler
   {
     VAR
       ProgressDialog@1004 : Dialog;
-      PerformanceProfiler@1000 : DotNet "'EtwPerformanceProfiler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.EtwPerformanceProfiler.EtwPerformanceProfiler";
+      PerformanceProfiler@1000 : DotNet "'EtwPerformanceProfiler, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null'.EtwPerformanceProfiler.EtwPerformanceProfiler";
       ProfilerStarted@1001 : Boolean INDATASET;
       TargetSessionIDEditable@1008 : Boolean;
       TargetSessionID@1003 : Integer INDATASET;

--- a/EtwPerformanceProfiler/App Objects/PAG50001.txt
+++ b/EtwPerformanceProfiler/App Objects/PAG50001.txt
@@ -141,7 +141,7 @@ OBJECT Page 50001 Performance Profiler Archive
   {
     VAR
       ProgressDialog@1004 : Dialog;
-      PerformanceProfiler@1000 : DotNet "'EtwPerformanceProfiler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.EtwPerformanceProfiler.EtwPerformanceProfiler";
+      PerformanceProfiler@1000 : DotNet "'EtwPerformanceProfiler, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null'.EtwPerformanceProfiler.EtwPerformanceProfiler";
       ProfilerStarted@1001 : Boolean INDATASET;
       I@1002 : Integer;
       TargetSessionCode@1003 : Code[20] INDATASET;

--- a/EtwPerformanceProfiler/EtwEventProcessors/NavEventsPayloadIndexes.cs
+++ b/EtwPerformanceProfiler/EtwEventProcessors/NavEventsPayloadIndexes.cs
@@ -30,11 +30,6 @@ namespace EtwPerformanceProfiler
         internal const int SessionIdPayloadIndex = 1;
 
         /// <summary>
-        /// The index of the user name payload parameter as defined in the ETW manifest.
-        /// </summary>
-        internal const int UserNamePayloadIndex = 2;
-
-        /// <summary>
         /// The index of the connection type payload parameter as defined in the ETW manifest.
         /// </summary>
         internal const int ConnectionTypePayloadIndex = 3;
@@ -47,27 +42,27 @@ namespace EtwPerformanceProfiler
         /// <summary>
         /// The index of the object type payload parameter as defined in the ETW manifest.
         /// </summary>
-        internal const int ObjectTypePayloadIndex = 3;
+        internal const int ObjectTypePayloadIndex = 2;
 
         /// <summary>
         /// The index of the object id payload parameter as defined in the ETW manifest.
         /// </summary>
-        internal const int ObjectIdPayloadIndex = 4;
+        internal const int ObjectIdPayloadIndex = 3;
 
         /// <summary>
         /// The index of the function name payload parameter as defined in the ETW manifest.
         /// </summary>
-        internal const int ALFunctionNamePayloadIndex = 5;
+        internal const int ALFunctionNamePayloadIndex = 4;
 
         /// <summary>
         /// The index of the line number payload parameter as defined in the ETW manifest.
         /// </summary>
-        internal const int LineNoPayloadIndex = 6;
+        internal const int LineNoPayloadIndex = 5;
 
         /// <summary>
         /// The index of the statement payload parameter as defined in the ETW manifest.
         /// </summary>
-        internal const int ALStatementPayloadIndex = 7;
+        internal const int ALStatementPayloadIndex = 6;
         #endregion
 
     }

--- a/EtwPerformanceProfiler/EtwPerformanceProfiler.cs
+++ b/EtwPerformanceProfiler/EtwPerformanceProfiler.cs
@@ -173,6 +173,16 @@ namespace EtwPerformanceProfiler
                     return 9;
                 }
 
+                if (0 == String.Compare(objectType, "System", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return 10;
+                }
+
+                if (0 == String.Compare(objectType, "PageExtension", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return 12;
+                }
+
                 throw new InvalidOperationException("Invalid object type.");
             }
         }

--- a/EtwPerformanceProfiler/ProfilerEventAggregators/EventAggregator.cs
+++ b/EtwPerformanceProfiler/ProfilerEventAggregators/EventAggregator.cs
@@ -12,11 +12,7 @@ namespace EtwPerformanceProfiler
 {
     abstract class EventAggregator
     {
-        protected static string GetUserName(TraceEvent traceEvent)
-        {
-            return (string)traceEvent.PayloadValue(NavEventsPayloadIndexes.UserNamePayloadIndex);
-        }
-
+     
         protected static int GetSessionId(TraceEvent traceEvent)
         {
             return (int)traceEvent.PayloadValue(NavEventsPayloadIndexes.SessionIdPayloadIndex);

--- a/EtwPerformanceProfiler/ProfilerEventAggregators/SingleSessionEventAggregator.cs
+++ b/EtwPerformanceProfiler/ProfilerEventAggregators/SingleSessionEventAggregator.cs
@@ -181,7 +181,6 @@ namespace EtwPerformanceProfiler
             {
                 this.firstEvent = false;
 
-                this.aggregatedCallTree.StatementName += " User: " + GetUserName(traceEvent) + ";";
             }
 
             string objectType = string.Empty;
@@ -198,8 +197,7 @@ namespace EtwPerformanceProfiler
             if ((int) traceEvent.ID == NavEvents.ALFunctionStatement)
             {
                 // Only statements have line numbers.
-
-                lineNo = (int) traceEvent.PayloadValue(NavEventsPayloadIndexes.LineNoPayloadIndex);
+                lineNo = System.Convert.ToInt32(traceEvent.PayloadValue(NavEventsPayloadIndexes.LineNoPayloadIndex));
             }
 
             string statement;

--- a/EtwPerformanceProfiler/Properties/AssemblyInfo.cs
+++ b/EtwPerformanceProfiler/Properties/AssemblyInfo.cs
@@ -40,8 +40,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 [assembly: InternalsVisibleTo("EtwPerformanceProfilerTest")]
 


### PR DESCRIPTION
This PR updates the NAV ETW profiler to support changes made to the events in NAV 2018. MS have stated that the events may continue to change in the future so this is a temporary fix.