### PR TITLE
Fix sleep routine in Profiler Stop action

### DIFF
--- a/EtwPerformanceProfiler/App Objects/PAG50000.txt
+++ b/EtwPerformanceProfiler/App Objects/PAG50000.txt
@@ -86,8 +86,8 @@ OBJECT Page 50000 Performance Profiler
                       Image=Stop;
                       PromotedCategory=Process;
                       OnAction=BEGIN
-                                 WaitForDataToBeCollected;
                                  PerformanceProfiler.Stop;
+                                 WaitForDataToBeCollected;
 
                                  ProfilerStarted := FALSE;
 


### PR DESCRIPTION
As stop command was executed after waiting for 3 secs, there was not enough time to collect the data. Switched the sequence.