### PR TITLE
Added support for ObjectType 'TableExtension'

### DIFF
--- a/EtwPerformanceProfiler/App Objects/TAB50000.txt
+++ b/EtwPerformanceProfiler/App Objects/TAB50000.txt
@@ -16,8 +16,8 @@ OBJECT Table 50000 Performance Profiler Events
     { 2   ;   ;Session ID          ;Integer        }
     { 3   ;   ;Indentation         ;Integer        }
     { 4   ;   ;Object Type         ;Option        ;CaptionML=ENU=Object Type;
-                                                   OptionCaptionML=ENU=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber;
-                                                   OptionString=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber }
+                                                   OptionCaptionML=ENU=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber,TableExtension,PageExtension;
+                                                   OptionString=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber,TableExtension,PageExtension }
     { 5   ;   ;Object ID           ;Integer       ;TableRelation=Object.ID WHERE (Type=FIELD(Object Type));
                                                    TestTableRelation=No;
                                                    CaptionML=ENU=Object ID }

--- a/EtwPerformanceProfiler/App Objects/TAB50001.txt
+++ b/EtwPerformanceProfiler/App Objects/TAB50001.txt
@@ -15,8 +15,8 @@ OBJECT Table 50001 Performance Profiler Archive
     { 1   ;   ;Id                  ;Integer        }
     { 3   ;   ;Indentation         ;Integer        }
     { 4   ;   ;Object Type         ;Option        ;CaptionML=ENU=Object Type;
-                                                   OptionCaptionML=ENU=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber;
-                                                   OptionString=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber }
+                                                   OptionCaptionML=ENU=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber,TableExtension,PageExtension;
+                                                   OptionString=TableData,Table,Form,Report,Dataport,Codeunit,XMLport,MenuSuite,Page,Query,System,FieldNumber,TableExtension,PageExtension }
     { 5   ;   ;Object ID           ;Integer       ;TableRelation=Object.ID WHERE (Type=FIELD(Object Type));
                                                    TestTableRelation=No;
                                                    CaptionML=ENU=Object ID }

--- a/EtwPerformanceProfiler/EtwPerformanceProfiler.cs
+++ b/EtwPerformanceProfiler/EtwPerformanceProfiler.cs
@@ -178,9 +178,14 @@ namespace EtwPerformanceProfiler
                     return 10;
                 }
 
-                if (0 == String.Compare(objectType, "PageExtension", System.StringComparison.OrdinalIgnoreCase))
+                if (0 == String.Compare(objectType, "TableExtension", System.StringComparison.OrdinalIgnoreCase))
                 {
                     return 12;
+                }
+
+                if (0 == String.Compare(objectType, "PageExtension", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return 13;
                 }
 
                 throw new InvalidOperationException("Invalid object type.");


### PR DESCRIPTION
Without these changes the tool generates an error if table extensions are used in the current database and these are touched during analyses.

The error generated contains the following message:
'EtwPerformanceProfiler.EtwPerformanceProfiler.CallTreeCurrentStatementOwningObjectType failed with this message: Invalid object type'.